### PR TITLE
Sqlbox-like cdr logging. Not tested very well.

### DIFF
--- a/example/pluginbox_cdr.conf.example
+++ b/example/pluginbox_cdr.conf.example
@@ -1,0 +1,14 @@
+group = sqlbox
+id = cdrplugin-db
+sql-log-table = sent_sms
+save-mo = 1
+save-mt = 1
+save-dlr = 1
+
+group = mysql-connection
+id = cdrplugin-db
+host = localhost
+username = kannel
+password = secret
+database = kannel
+max-connections = 1

--- a/plugins/pluginbox_cdr.c
+++ b/plugins/pluginbox_cdr.c
@@ -1,0 +1,283 @@
+/* ====================================================================
+ * The Kannel Software License, Version 1.0
+ *
+ * Copyright (c) 2001-2016 Kannel Group
+ * Copyright (c) 1998-2001 WapIT Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution,
+ *    if any, must include the following acknowledgment:
+ *       "This product includes software developed by the
+ *        Kannel Group (http://www.kannel.org/)."
+ *    Alternately, this acknowledgment may appear in the software itself,
+ *    if and wherever such third-party acknowledgments normally appear.
+ *
+ * 4. The names "Kannel" and "Kannel Group" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please
+ *    contact org@kannel.org.
+ *
+ * 5. Products derived from this software may not be called "Kannel",
+ *    nor may "Kannel" appear in their name, without prior written
+ *    permission of the Kannel Group.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE KANNEL GROUP OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Kannel Group.  For more information on
+ * the Kannel Group, please see <http://www.kannel.org/>.
+ *
+ * Portions of this software are based upon software originally written at
+ * WapIT Ltd., Helsinki, Finland for the Kannel project.
+ *
+ *
+ * @author Rene Kluwen <rene.kluwen@chimit.nl>
+ */
+
+#include "gwlib/gwlib.h"
+#include "gw/pluginbox_plugin.h"
+#include "sqlbox_sql.inc"
+#include "sqlbox_mysql.inc"
+
+typedef struct {
+	Octstr *id;
+	int save_mo, save_mt, save_dlr;
+	struct server_type *backend;
+} PluginCdr;
+
+#define PLUGINBOX_LOG_PREFIX "[CDR-PLUGIN] "
+
+PluginCdr *pluginbox_cdr_plugin_create() {
+    PluginCdr *plugin_cdr = gw_malloc(sizeof(PluginCdr));
+    plugin_cdr->id = NULL;
+    plugin_cdr->backend = NULL;
+    return plugin_cdr;
+}
+
+void pluginbox_cdr_plugin_destroy(PluginCdr *plugin_cdr) {
+    if (plugin_cdr->id) octstr_destroy(plugin_cdr->id);
+    if (plugin_cdr->backend && plugin_cdr->backend->sql_leave) {
+	plugin_cdr->backend->sql_leave();
+    }
+    gw_free(plugin_cdr);
+}
+
+static int sqlbox_is_allowed_in_group(Octstr *group, Octstr *variable)
+{
+    Octstr *groupstr;
+
+    groupstr = octstr_imm("group");
+
+    #define OCTSTR(name) \
+        if (octstr_compare(octstr_imm(#name), variable) == 0) \
+        return 1;
+    #define SINGLE_GROUP(name, fields) \
+        if (octstr_compare(octstr_imm(#name), group) == 0) { \
+        if (octstr_compare(groupstr, variable) == 0) \
+        return 1; \
+        fields \
+        return 0; \
+    }
+    #define MULTI_GROUP(name, fields) \
+        if (octstr_compare(octstr_imm(#name), group) == 0) { \
+        if (octstr_compare(groupstr, variable) == 0) \
+        return 1; \
+        fields \
+        return 0; \
+    }
+    #include "sqlbox-cfg.def"
+
+    return 0;
+}
+
+#undef OCTSTR
+#undef SINGLE_GROUP
+#undef MULTI_GROUP
+
+static int sqlbox_is_single_group(Octstr *query)
+{
+    #define OCTSTR(name)
+    #define SINGLE_GROUP(name, fields) \
+        if (octstr_compare(octstr_imm(#name), query) == 0) \
+        return 1;
+    #define MULTI_GROUP(name, fields) \
+        if (octstr_compare(octstr_imm(#name), query) == 0) \
+        return 0;
+    #include "sqlbox-cfg.def"
+    return 0;
+}
+
+void pluginbox_cdr_configure(PluginCdr *plugin_cdr, Cfg *cfg)
+{
+    CfgGroup *grp;
+
+    grp = cfg_get_single_group(cfg, octstr_imm("sqlbox"));
+    /* set up save parameters */
+    if (cfg_get_bool(&plugin_cdr->save_mo, grp, octstr_imm("save-mo")) == -1)
+        plugin_cdr->save_mo = 1;
+
+    if (cfg_get_bool(&plugin_cdr->save_mt, grp, octstr_imm("save-mt")) == -1)
+        plugin_cdr->save_mt = 1;
+
+    if (cfg_get_bool(&plugin_cdr->save_dlr, grp, octstr_imm("save-dlr")) == -1)
+        plugin_cdr->save_dlr = 1;
+}
+
+void pluginbox_cdr_shutdown(PluginBoxPlugin *pluginbox_plugin) {
+    PluginCdr *plugin_cdr = pluginbox_plugin->context;
+
+    pluginbox_cdr_plugin_destroy(plugin_cdr);
+    info(0, PLUGINBOX_LOG_PREFIX "Shutdown complete");
+}
+
+void pluginbox_cdr_process(PluginBoxPlugin *pluginbox_plugin, PluginBoxMsg *pluginbox_msg) {
+    PluginCdr *plugin_cdr;
+    Msg *msg_escaped;
+
+    if (msg_type(pluginbox_msg->msg) == sms) {
+	debug("pluginbox.http.process", 0, PLUGINBOX_LOG_PREFIX "Got plugin message chain %ld", pluginbox_msg->chain);
+	plugin_cdr = (PluginCdr *)pluginbox_plugin->context;
+	msg_escaped = msg_duplicate(pluginbox_msg->msg);
+        switch (pluginbox_msg->msg->sms.sms_type) {
+	case report_mo:
+	    if (plugin_cdr->save_dlr) {
+	        plugin_cdr->backend->sql_save_msg(msg_escaped, octstr_imm("DLR"));
+	    }
+	    break;
+	case mo:
+	    if (plugin_cdr->save_mo) {
+	        plugin_cdr->backend->sql_save_msg(msg_escaped, octstr_imm("MO"));
+	    }
+	    break;
+	case mt_reply:
+	case mt_push:
+	    if (plugin_cdr->save_mt) {
+	        plugin_cdr->backend->sql_save_msg(msg_escaped, octstr_imm("MT"));
+	    }
+	    break;
+	}
+	msg_destroy(msg_escaped);
+    }
+    pluginbox_msg->callback(pluginbox_msg);
+}
+
+#if 0
+int pluginbox_cdr_configure(PluginCdr *plugin_cdr) {
+    Octstr *tmp_str;
+    long tmp_long;
+    PluginBoxPlugin *pluginbox_plugin = plugin_http->plugin;
+
+    if(!octstr_len(pluginbox_plugin->id)) {
+        error(0, PLUGINBOX_LOG_PREFIX "An 'id' parameter must be specified in the pluginbox-plugin group for HTTP plugins");
+        return 0;
+    }
+
+    Cfg *cfg = cfg_create(pluginbox_plugin->args);
+
+    if(cfg_read(cfg) == -1) {
+        error(0, PLUGINBOX_LOG_PREFIX "Couldn't load HTTP plugin %s configuration", octstr_get_cstr(pluginbox_plugin->id));
+        cfg_destroy(cfg);
+        return 0;
+    }
+
+    List *grplist = cfg_get_multi_group(cfg, octstr_imm("pluginbox-http"));
+    CfgGroup *grp;
+    Octstr *config_id;
+    while (grplist && (grp = gwlist_extract_first(grplist)) != NULL) {
+        config_id = cfg_get(grp, octstr_imm("id"));
+
+        if(octstr_len(config_id) && (octstr_compare(config_id, pluginbox_plugin->id) == 0)) {
+            octstr_destroy(config_id);
+            goto found;
+        }
+        octstr_destroy(config_id);
+    }
+
+    gwlist_destroy(grplist, NULL);
+
+    goto error;
+
+found:
+    info(0, PLUGINBOX_LOG_PREFIX "Loading configuration for %s", octstr_get_cstr(pluginbox_plugin->id));
+
+    plugin_http->url = cfg_get(grp, octstr_imm("url"));
+
+    if(!octstr_len(plugin_http->url)) {
+        error(0, PLUGINBOX_LOG_PREFIX "No 'url' specified in 'pluginbox-http' group id %s", octstr_get_cstr(pluginbox_plugin->id));
+        return 0;
+    }
+
+    if(cfg_get_integer(&tmp_long,grp, octstr_imm("max-pending-requests")) == -1) {
+        tmp_long = PLUGINBOX_HTTP_DEFAULT_MAX_PENDING;
+    }
+
+    info(0, PLUGINBOX_LOG_PREFIX "Max pending requests set to %ld", tmp_long);
+
+    plugin_http->max_pending_requests = semaphore_create(tmp_long);
+
+    gwlist_destroy(grplist, NULL);
+
+    cfg_destroy(cfg);
+
+
+    return 1;
+error:
+    error(0, PLUGINBOX_LOG_PREFIX "No matching 'pluginbox-http' group found for id %s, cannot initialize", octstr_get_cstr(pluginbox_plugin->id));
+    cfg_destroy(cfg);
+    return 0;
+}
+#endif
+
+int pluginbox_cdr_init(PluginBoxPlugin *pluginbox_plugin) {
+	info(0, PLUGINBOX_LOG_PREFIX "Using configuration from %s", octstr_get_cstr(pluginbox_plugin->args));
+	cfg_add_hooks(sqlbox_is_allowed_in_group, sqlbox_is_single_group);
+
+	Cfg *cfg = cfg_create(pluginbox_plugin->args);
+	if(cfg_read(cfg) == -1) {
+		error(0, PLUGINBOX_LOG_PREFIX "Couldn't load CDR plugin %s configuration", octstr_get_cstr(pluginbox_plugin->id));
+		cfg_destroy(cfg);
+		return 0;
+	}
+	pluginbox_plugin->context = pluginbox_cdr_plugin_create();
+	pluginbox_cdr_configure(pluginbox_plugin->context, cfg);
+	((PluginCdr *)pluginbox_plugin->context)->backend = sqlbox_init_sql(cfg);
+	((PluginCdr *)pluginbox_plugin->context)->backend->sql_enter(cfg);
+	cfg_destroy(cfg);
+	pluginbox_plugin->direction = PLUGINBOX_MESSAGE_FROM_SMSBOX | PLUGINBOX_MESSAGE_FROM_BEARERBOX;
+	pluginbox_plugin->process = pluginbox_cdr_process;
+	pluginbox_plugin->shutdown = pluginbox_cdr_shutdown;
+	return 1;
+}
+
+static char *type_as_str(Msg *msg)
+{
+    switch (msg->type) {
+#define MSG(t, stmt) case t: return #t;
+#include "gw/msg-decl.h"
+        default:
+            return "unknown type";
+    }
+}

--- a/plugins/sqlbox-cfg.def
+++ b/plugins/sqlbox-cfg.def
@@ -1,0 +1,16 @@
+/* ==================================================================
+ * Sqlbox-cfg.def - Definition of configuration groups and variables
+ *
+ * Martin Conte
+ *
+ */
+
+SINGLE_GROUP(sqlbox,
+    OCTSTR(id)
+    OCTSTR(sql-log-table)
+    OCTSTR(log-file)
+    OCTSTR(log-level)
+    OCTSTR(save-mo)
+    OCTSTR(save-mt)
+    OCTSTR(save-dlr)
+)

--- a/plugins/sqlbox_mysql.h
+++ b/plugins/sqlbox_mysql.h
@@ -1,0 +1,69 @@
+#include "gwlib/gwlib.h"
+
+#if defined(HAVE_MYSQL) || defined(HAVE_SDB)
+
+#define SQLBOX_MYSQL_CREATE_LOG_TABLE "CREATE TABLE IF NOT EXISTS %S ( \
+sql_id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, \
+momt ENUM('MO', 'MT', 'DLR') NULL, sender VARCHAR(20) NULL, \
+receiver VARCHAR(20) NULL, udhdata BLOB NULL, msgdata TEXT NULL, \
+time BIGINT(20) NULL, smsc_id VARCHAR(255) NULL, service VARCHAR(255) NULL, \
+account VARCHAR(255) NULL, id BIGINT(20) NULL, sms_type BIGINT(20) NULL, \
+mclass BIGINT(20) NULL, mwi BIGINT(20) NULL, coding BIGINT(20) NULL, \
+compress BIGINT(20) NULL, validity BIGINT(20) NULL, deferred BIGINT(20) NULL, \
+dlr_mask BIGINT(20) NULL, dlr_url VARCHAR(255) NULL, pid BIGINT(20) NULL, \
+alt_dcs BIGINT(20) NULL, rpi BIGINT(20) NULL, charset VARCHAR(255) NULL, \
+boxc_id VARCHAR(255) NULL, binfo VARCHAR(255) NULL, meta_data TEXT, \
+priority BIGINT(20) NULL, foreign_id VARCHAR(255) NULL)"
+
+#define SQLBOX_MYSQL_CREATE_INSERT_TABLE "CREATE TABLE IF NOT EXISTS %S ( \
+sql_id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY, \
+momt ENUM('MO', 'MT') NULL, sender VARCHAR(20) NULL, \
+receiver VARCHAR(20) NULL, udhdata BLOB NULL, msgdata TEXT NULL, \
+time BIGINT(20) NULL, smsc_id VARCHAR(255) NULL, service VARCHAR(255) NULL, \
+account VARCHAR(255) NULL, id BIGINT(20) NULL, sms_type BIGINT(20) NULL, \
+mclass BIGINT(20) NULL, mwi BIGINT(20) NULL, coding BIGINT(20) NULL, \
+compress BIGINT(20) NULL, validity BIGINT(20) NULL, deferred BIGINT(20) NULL, \
+dlr_mask BIGINT(20) NULL, dlr_url VARCHAR(255) NULL, pid BIGINT(20) NULL, \
+alt_dcs BIGINT(20) NULL, rpi BIGINT(20) NULL, charset VARCHAR(255) NULL, \
+boxc_id VARCHAR(255) NULL, binfo VARCHAR(255) NULL, meta_data TEXT, \
+priority BIGINT(20) NULL, foreign_id VARCHAR(255) NULL)"
+
+#define SQLBOX_MYSQL_SELECT_QUERY "SELECT sql_id, momt, sender, receiver, udhdata, \
+msgdata, time, smsc_id, service, account, id, sms_type, mclass, mwi, coding, \
+compress, validity, deferred, dlr_mask, dlr_url, pid, alt_dcs, rpi, \
+charset, boxc_id, binfo, meta_data, priority FROM %S LIMIT 0,1"
+
+#define SQLBOX_MYSQL_SELECT_LIST_QUERY "SELECT sql_id, momt, sender, receiver, udhdata, \
+msgdata, time, smsc_id, service, account, id, sms_type, mclass, mwi, coding, \
+compress, validity, deferred, dlr_mask, dlr_url, pid, alt_dcs, rpi, \
+charset, boxc_id, binfo, meta_data, priority FROM %S LIMIT 0,%ld"
+
+#define SQLBOX_MYSQL_INSERT_QUERY "INSERT INTO %S ( sql_id, momt, sender, \
+receiver, udhdata, msgdata, time, smsc_id, service, account, sms_type, \
+mclass, mwi, coding, compress, validity, deferred, dlr_mask, dlr_url, \
+pid, alt_dcs, rpi, charset, boxc_id, binfo, meta_data, priority, foreign_id ) VALUES ( \
+NULL, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, \
+%S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S)"
+
+#define SQLBOX_MYSQL_INSERT_LIST_QUERY "INSERT INTO %S ( sql_id, momt, sender, \
+receiver, udhdata, msgdata, time, smsc_id, service, account, sms_type, \
+mclass, mwi, coding, compress, validity, deferred, dlr_mask, dlr_url, \
+pid, alt_dcs, rpi, charset, boxc_id, binfo, meta_data, priority, foreign_id ) VALUES %S"
+
+#define SQLBOX_MYSQL_DELETE_QUERY "DELETE FROM %S WHERE sql_id = %S"
+#define SQLBOX_MYSQL_DELETE_LIST_QUERY "DELETE FROM %S WHERE sql_id in (%S)"
+
+#endif /* HAVE_MYSQL || HAVE_SDB */
+
+#ifdef HAVE_MYSQL
+#include "gw/msg.h"
+#include "sqlbox_sql.h"
+void sql_save_msg(Msg *msg, Octstr *momt);
+Msg *mysql_fetch_msg();
+void sql_shutdown();
+struct server_type *sqlbox_init_mysql(Cfg* cfg);
+#ifndef sqlbox_mysql_c
+extern
+#endif
+Octstr *sqlbox_id;
+#endif

--- a/plugins/sqlbox_mysql.inc
+++ b/plugins/sqlbox_mysql.inc
@@ -1,0 +1,432 @@
+#include "gwlib/gwlib.h"
+#ifdef HAVE_MYSQL
+#include "gwlib/dbpool.h"
+#include <mysql/mysql.h>
+#define sqlbox_mysql_c
+#include "sqlbox_mysql.h"
+
+#define sql_update mysql_update
+#define sql_select mysql_select
+#define MYSQL_ERR_NOSUCHFIELD 1054
+
+static Octstr *sqlbox_logtable;
+static Octstr *sqlbox_insert_table;
+
+/*
+ * Our connection pool to mysql.
+ */
+
+static DBPool *pool = NULL;
+
+static void mysql_update(const Octstr *sql)
+{
+    int state;
+    DBPoolConn *pc;
+
+#if defined(SQLBOX_TRACE)
+     debug("SQLBOX", 0, "sql: %s", octstr_get_cstr(sql));
+#endif
+
+    pc = dbpool_conn_consume(pool);
+    if (pc == NULL) {
+        error(0, "MYSQL: Database pool got no connection! DB update failed!");
+        return;
+    }
+
+    state = mysql_query(pc->conn, octstr_get_cstr(sql));
+    if (state != 0)
+        error(0, "MYSQL: %s", mysql_error(pc->conn));
+        if (mysql_errno(pc->conn) == MYSQL_ERR_NOSUCHFIELD) {
+            error(0, "Try to recreate insert and log tables. The structure may have changed. See ChangeLog.");
+        }
+
+    dbpool_conn_produce(pc);
+}
+
+static MYSQL_RES* mysql_select(const Octstr *sql)
+{
+    int state;
+    MYSQL_RES *result = NULL;
+    DBPoolConn *pc;
+
+#if defined(SQLBOX_TRACE)
+    debug("SQLBOX", 0, "sql: %s", octstr_get_cstr(sql));
+#endif
+
+    pc = dbpool_conn_consume(pool);
+    if (pc == NULL) {
+        error(0, "MYSQL: Database pool got no connection! DB update failed!");
+        return NULL;
+    }
+
+    state = mysql_query(pc->conn, octstr_get_cstr(sql));
+    if (state != 0) {
+        error(0, "MYSQL: %s", mysql_error(pc->conn));
+        if (mysql_errno(pc->conn) == MYSQL_ERR_NOSUCHFIELD) {
+            error(0, "Try to recreate insert and log tables. The structure may have changed. See ChangeLog.");
+        }
+    } else {
+        result = mysql_store_result(pc->conn);
+    }
+
+    dbpool_conn_produce(pc);
+
+    return result;
+}
+
+void sqlbox_configure_mysql(Cfg* cfg)
+{
+    CfgGroup *grp;
+    Octstr *sql;
+
+    if (!(grp = cfg_get_single_group(cfg, octstr_imm("sqlbox"))))
+        panic(0, "SQLBOX: MySQL: group 'sqlbox' is not specified!");
+
+    sqlbox_logtable = cfg_get(grp, octstr_imm("sql-log-table"));
+    if (sqlbox_logtable == NULL) {
+        panic(0, "No 'sql-log-table' not configured.");
+    }
+#if 0
+    sqlbox_insert_table = cfg_get(grp, octstr_imm("sql-insert-table"));
+    if (sqlbox_insert_table == NULL) {
+        panic(0, "No 'sql-insert-table' not configured.");
+    }
+#endif
+
+    /* create send_sms && sent_sms tables if they do not exist */
+    sql = octstr_format(SQLBOX_MYSQL_CREATE_LOG_TABLE, sqlbox_logtable);
+    sql_update(sql);
+    octstr_destroy(sql);
+#if 0
+    sql = octstr_format(SQLBOX_MYSQL_CREATE_INSERT_TABLE, sqlbox_insert_table);
+    sql_update(sql);
+    octstr_destroy(sql);
+#endif
+    /* end table creation */
+}
+
+#define octstr_null_create(x) ((x != NULL) ? octstr_create(x) : octstr_create(""))
+#define atol_null(x) ((x != NULL) ? atol(x) : -1)
+Msg *mysql_fetch_msg()
+{
+    Msg *msg = NULL;
+    Octstr *sql, *delet, *id;
+    MYSQL_RES *res;
+    MYSQL_ROW row;
+
+    sql = octstr_format(SQLBOX_MYSQL_SELECT_QUERY, sqlbox_insert_table);
+    res = mysql_select(sql);
+    if (res == NULL) {
+        debug("sqlbox", 0, "SQL statement failed: %s", octstr_get_cstr(sql));
+    }
+    else {
+        if (mysql_num_rows(res) >= 1) {
+            row = mysql_fetch_row(res);
+            id = octstr_null_create(row[0]);
+            /* save fields in this row as msg struct */
+            msg = msg_create(sms);
+            /* we abuse the foreign_id field in the message struct for our sql_id value */
+            msg->sms.foreign_id = octstr_null_create(row[0]);
+            msg->sms.sender     = octstr_null_create(row[2]);
+            msg->sms.receiver   = octstr_null_create(row[3]);
+            msg->sms.udhdata    = octstr_null_create(row[4]);
+            msg->sms.msgdata    = octstr_null_create(row[5]);
+            msg->sms.time       = atol_null(row[6]);
+            msg->sms.smsc_id    = octstr_null_create(row[7]);
+            msg->sms.service    = octstr_null_create(row[8]);
+            msg->sms.account    = octstr_null_create(row[9]);
+            msg->sms.sms_type   = atol_null(row[11]);
+            msg->sms.mclass     = atol_null(row[12]);
+            msg->sms.mwi        = atol_null(row[13]);
+            msg->sms.coding     = atol_null(row[14]);
+            msg->sms.compress   = atol_null(row[15]);
+            msg->sms.validity   = atol_null(row[16]);
+            msg->sms.deferred   = atol_null(row[17]);
+            msg->sms.dlr_mask   = atol_null(row[18]);
+            msg->sms.dlr_url    = octstr_null_create(row[19]);
+            msg->sms.pid        = atol_null(row[20]);
+            msg->sms.alt_dcs    = atol_null(row[21]);
+            msg->sms.rpi        = atol_null(row[22]);
+            msg->sms.charset    = octstr_null_create(row[23]);
+            msg->sms.binfo      = octstr_null_create(row[25]);
+            msg->sms.meta_data  = octstr_null_create(row[26]);
+            msg->sms.priority   = atol_null(row[27]);
+            if (row[24] == NULL) {
+                msg->sms.boxc_id= octstr_duplicate(sqlbox_id);
+            }
+            else {
+                msg->sms.boxc_id= octstr_null_create(row[24]);
+            }
+            /* delete current row */
+            delet = octstr_format(SQLBOX_MYSQL_DELETE_QUERY, sqlbox_insert_table, id);
+#if defined(SQLBOX_TRACE)
+            debug("SQLBOX", 0, "sql: %s", octstr_get_cstr(delet));
+#endif
+            mysql_update(delet);
+            octstr_destroy(id);
+            octstr_destroy(delet);
+        }
+        mysql_free_result(res);
+    }
+    octstr_destroy(sql);
+    return msg;
+}
+
+int mysql_fetch_msg_list(List *qlist, long limit)
+{
+    Msg *msg = NULL;
+    Octstr *sql, *delet, *id;
+    MYSQL_RES *res;
+    MYSQL_ROW row;
+    int ret = 0;
+
+    sql = octstr_format(SQLBOX_MYSQL_SELECT_LIST_QUERY, sqlbox_insert_table, limit);
+    res = mysql_select(sql);
+    if (res == NULL) {
+        debug("sqlbox", 0, "SQL statement failed: %s", octstr_get_cstr(sql));
+    }
+    else {
+	ret = mysql_num_rows(res);
+        if (ret >= 1) {
+            while (row = mysql_fetch_row(res)) {
+                /* save fields in this row as msg struct */
+                msg = msg_create(sms);
+                /* we abuse the foreign_id field in the message struct for our sql_id value */
+                msg->sms.foreign_id = octstr_null_create(row[0]);
+                msg->sms.sender     = octstr_null_create(row[2]);
+                msg->sms.receiver   = octstr_null_create(row[3]);
+                msg->sms.udhdata    = octstr_null_create(row[4]);
+                msg->sms.msgdata    = octstr_null_create(row[5]);
+                msg->sms.time       = atol_null(row[6]);
+                msg->sms.smsc_id    = octstr_null_create(row[7]);
+                msg->sms.service    = octstr_null_create(row[8]);
+                msg->sms.account    = octstr_null_create(row[9]);
+                msg->sms.sms_type   = atol_null(row[11]);
+                msg->sms.mclass     = atol_null(row[12]);
+                msg->sms.mwi        = atol_null(row[13]);
+                msg->sms.coding     = atol_null(row[14]);
+                msg->sms.compress   = atol_null(row[15]);
+                msg->sms.validity   = atol_null(row[16]);
+                msg->sms.deferred   = atol_null(row[17]);
+                msg->sms.dlr_mask   = atol_null(row[18]);
+                msg->sms.dlr_url    = octstr_null_create(row[19]);
+                msg->sms.pid        = atol_null(row[20]);
+                msg->sms.alt_dcs    = atol_null(row[21]);
+                msg->sms.rpi        = atol_null(row[22]);
+                msg->sms.charset    = octstr_null_create(row[23]);
+                msg->sms.binfo      = octstr_null_create(row[25]);
+                msg->sms.meta_data  = octstr_null_create(row[26]);
+                msg->sms.priority   = atol_null(row[27]);
+                if (row[24] == NULL) {
+                    msg->sms.boxc_id= octstr_duplicate(sqlbox_id);
+                }
+                else {
+                    msg->sms.boxc_id= octstr_null_create(row[24]);
+                }
+                gwlist_produce(qlist, msg);
+            }
+        }
+        mysql_free_result(res);
+    }
+    octstr_destroy(sql);
+    return ret;
+}
+
+static Octstr *get_numeric_value_or_return_null(long int num)
+{
+    if (num == -1) {
+        return octstr_create("NULL");
+    }
+    return octstr_format("%ld", num);
+}
+
+static Octstr *get_string_value_or_return_null(Octstr *str)
+{
+    if (str == NULL) {
+        return octstr_create("NULL");
+    }
+    if (octstr_compare(str, octstr_imm("")) == 0) {
+        return octstr_create("NULL");
+    }
+    /* todo: create a new string instead of inline replacing */
+    octstr_replace(str, octstr_imm("\\"), octstr_imm("\\\\"));
+    octstr_replace(str, octstr_imm("\'"), octstr_imm("\\\'"));
+    return octstr_format("\'%S\'", str);
+}
+
+#define st_num(x) (stuffer[stuffcount++] = get_numeric_value_or_return_null(x))
+#define st_str(x) (stuffer[stuffcount++] = get_string_value_or_return_null(x))
+
+void mysql_save_msg(Msg *msg, Octstr *momt)
+{
+    Octstr *sql;
+    Octstr *stuffer[30];
+    int stuffcount = 0;
+
+    sql = octstr_format(SQLBOX_MYSQL_INSERT_QUERY, sqlbox_logtable, st_str(momt), st_str(msg->sms.sender),
+        st_str(msg->sms.receiver), st_str(msg->sms.udhdata), st_str(msg->sms.msgdata), st_num(msg->sms.time),
+        st_str(msg->sms.smsc_id), st_str(msg->sms.service), st_str(msg->sms.account), st_num(msg->sms.sms_type),
+        st_num(msg->sms.mclass), st_num(msg->sms.mwi), st_num(msg->sms.coding), st_num(msg->sms.compress),
+        st_num(msg->sms.validity), st_num(msg->sms.deferred), st_num(msg->sms.dlr_mask), st_str(msg->sms.dlr_url),
+        st_num(msg->sms.pid), st_num(msg->sms.alt_dcs), st_num(msg->sms.rpi), st_str(msg->sms.charset),
+        st_str(msg->sms.boxc_id), st_str(msg->sms.binfo), st_str(msg->sms.meta_data), st_num(msg->sms.priority), st_str(msg->sms.foreign_id));
+    sql_update(sql);
+    while (stuffcount > 0) {
+        octstr_destroy(stuffer[--stuffcount]);
+    }
+    octstr_destroy(sql);
+}
+
+/* save a list of messages and delete them from the insert table */
+void mysql_save_list(List *qlist, Octstr *momt, int save_mt)
+{
+    Octstr *sql, *values, *ids, *sep;
+    Octstr *stuffer[30];
+    int stuffcount = 0, first = 1;
+    Msg *msg;
+
+    values = save_mt ? octstr_create("") : NULL;
+    ids = octstr_create("");
+    sep = octstr_imm("");
+    while (gwlist_len(qlist) > 0 && (msg = gwlist_consume(qlist)) != NULL) {
+        if (save_mt) {
+            /* convert into urlencoded tekst first */
+            octstr_url_encode(msg->sms.msgdata);
+            octstr_url_encode(msg->sms.udhdata);
+            octstr_format_append(values, "%S (NULL, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S, %S)",
+                sep, st_str(momt), st_str(msg->sms.sender),
+                st_str(msg->sms.receiver), st_str(msg->sms.udhdata), st_str(msg->sms.msgdata), st_num(msg->sms.time),
+                st_str(msg->sms.smsc_id), st_str(msg->sms.service), st_str(msg->sms.account), st_num(msg->sms.sms_type),
+                st_num(msg->sms.mclass), st_num(msg->sms.mwi), st_num(msg->sms.coding), st_num(msg->sms.compress),
+                st_num(msg->sms.validity), st_num(msg->sms.deferred), st_num(msg->sms.dlr_mask), st_str(msg->sms.dlr_url),
+                st_num(msg->sms.pid), st_num(msg->sms.alt_dcs), st_num(msg->sms.rpi), st_str(msg->sms.charset),
+                st_str(msg->sms.boxc_id), st_str(msg->sms.binfo), st_str(msg->sms.meta_data), st_num(msg->sms.priority), st_str(msg->sms.foreign_id));
+        }
+        octstr_format_append(ids, "%S %S", sep, msg->sms.foreign_id);
+        msg_destroy(msg);
+        if (first) {
+            first = 0;
+            sep = octstr_imm(",");
+        }
+        while (stuffcount > 0) {
+            octstr_destroy(stuffer[--stuffcount]);
+        }
+    }
+    if (save_mt) {
+        sql = octstr_format(SQLBOX_MYSQL_INSERT_LIST_QUERY, sqlbox_logtable, values);
+        octstr_destroy(values);
+        sql_update(sql);
+        octstr_destroy(sql);
+    }
+    sql = octstr_format(SQLBOX_MYSQL_DELETE_LIST_QUERY, sqlbox_insert_table, ids);
+    octstr_destroy(ids);
+    sql_update(sql);
+    octstr_destroy(sql);
+}
+
+void mysql_leave()
+{
+    dbpool_destroy(pool);
+}
+
+struct server_type *sqlbox_init_mysql(Cfg* cfg)
+{
+    CfgGroup *grp;
+    List *grplist;
+    Octstr *mysql_host, *mysql_user, *mysql_pass, *mysql_db, *mysql_id;
+    Octstr *p = NULL;
+    long pool_size, mysql_port;
+    int have_port;
+    DBConf *db_conf = NULL;
+    struct server_type *res = NULL;
+
+    /*
+     * check for all mandatory directives that specify the field names
+     * of the used MySQL table
+     */
+    if (!(grp = cfg_get_single_group(cfg, octstr_imm("sqlbox"))))
+        panic(0, "SQLBOX: MySQL: group 'sqlbox' is not specified!");
+
+    if (!(mysql_id = cfg_get(grp, octstr_imm("id"))))
+        panic(0, "SQLBOX: MySQL: directive 'id' is not specified!");
+
+    /*
+     * now grap the required information from the 'mysql-connection' group
+     * with the mysql-id we just obtained
+     *
+     * we have to loop through all available MySQL connection definitions
+     * and search for the one we are looking for
+     */
+
+     grplist = cfg_get_multi_group(cfg, octstr_imm("mysql-connection"));
+     while (grplist && (grp = (CfgGroup *)gwlist_extract_first(grplist)) != NULL) {
+         p = cfg_get(grp, octstr_imm("id"));
+         if (p != NULL && octstr_compare(p, mysql_id) == 0) {
+             goto found;
+         }
+         if (p != NULL) octstr_destroy(p);
+     }
+     panic(0, "SQLBOX: MySQL: connection settings for id '%s' are not specified!",
+         octstr_get_cstr(mysql_id));
+
+found:
+    octstr_destroy(p);
+    gwlist_destroy(grplist, NULL);
+
+    if (cfg_get_integer(&pool_size, grp, octstr_imm("max-connections")) == -1 || pool_size == 0)
+        pool_size = 1;
+
+    if (!(mysql_host = cfg_get(grp, octstr_imm("host"))))
+        panic(0, "SQLBOX: MySQL: directive 'host' is not specified!");
+    if (!(mysql_user = cfg_get(grp, octstr_imm("username"))))
+        panic(0, "SQLBOX: MySQL: directive 'username' is not specified!");
+    if (!(mysql_pass = cfg_get(grp, octstr_imm("password"))))
+        panic(0, "SQLBOX: MySQL: directive 'password' is not specified!");
+    if (!(mysql_db = cfg_get(grp, octstr_imm("database"))))
+        panic(0, "SQLBOX: MySQL: directive 'database' is not specified!");
+    have_port = (cfg_get_integer(&mysql_port, grp, octstr_imm("port")) != -1);
+
+    /*
+     * ok, ready to connect to MySQL
+     */
+    db_conf = gw_malloc(sizeof(DBConf));
+    gw_assert(db_conf != NULL);
+
+    db_conf->mysql = gw_malloc(sizeof(MySQLConf));
+    gw_assert(db_conf->mysql != NULL);
+
+    db_conf->mysql->host = mysql_host;
+    db_conf->mysql->username = mysql_user;
+    db_conf->mysql->password = mysql_pass;
+    db_conf->mysql->database = mysql_db;
+    if (have_port) {
+        db_conf->mysql->port = mysql_port;
+    }
+    else {
+        db_conf->mysql->port = 3306;
+    }
+
+    pool = dbpool_create(DBPOOL_MYSQL, db_conf, pool_size);
+    gw_assert(pool != NULL);
+
+    /*
+     * XXX should a failing connect throw panic?!
+     */
+    if (dbpool_conn_count(pool) == 0)
+        panic(0,"SQLBOX: MySQL: database pool has no connections!");
+
+    octstr_destroy(mysql_id);
+
+    res = gw_malloc(sizeof(struct server_type));
+    gw_assert(res != NULL);
+
+    res->type = octstr_create("MySQL");
+    res->sql_enter = sqlbox_configure_mysql;
+    res->sql_leave = mysql_leave;
+    res->sql_fetch_msg = mysql_fetch_msg;
+    res->sql_save_msg = mysql_save_msg;
+    res->sql_fetch_msg_list = mysql_fetch_msg_list;
+    res->sql_save_list = mysql_save_list;
+    return res;
+}
+#endif

--- a/plugins/sqlbox_sql.h
+++ b/plugins/sqlbox_sql.h
@@ -1,0 +1,58 @@
+#ifndef SQLBOX_SQL_H
+#define SQLBOX_SQL_H
+#include "gwlib/gwlib.h"
+#include "gw/msg.h"
+#include "sqlbox_mysql.h"
+
+struct server_type {
+    Octstr *type;
+    void (*sql_enter) (Cfg *);
+    void (*sql_leave) ();
+    Msg *(*sql_fetch_msg) ();
+    void (*sql_save_msg) (Msg *, Octstr *);
+    int  (*sql_fetch_msg_list) (List *, long);
+    void (*sql_save_list) (List *, Octstr *, int);
+};
+
+struct sqlbox_db_queries {
+    char *create_insert_table;
+    char *create_insert_sequence;
+    char *create_insert_trigger;
+    char *create_log_table;
+    char *create_log_sequence;
+    char *create_log_trigger;
+    char *select_query;
+    char *delete_query;
+    char *insert_query;
+};
+
+struct server_type *sqlbox_init_sql(Cfg *cfg);
+
+#ifndef sqlbox_sql_c
+extern
+#endif
+struct server_type *sql_type;
+
+#define gw_sql_fetch_msg sql_type->sql_fetch_msg
+#define gw_sql_fetch_msg_list sql_type->sql_fetch_msg_list
+#define gw_sql_save_list sql_type->sql_save_list
+#define gw_sql_save_msg(message, table) \
+    do { \
+        octstr_url_encode(message->sms.msgdata); \
+        octstr_url_encode(message->sms.udhdata); \
+        sql_type->sql_save_msg(message, table); \
+    } while (0)
+#define gw_sql_enter sql_type->sql_enter
+#define gw_sql_leave sql_type->sql_leave
+
+/* Macro to run the queries to create tables */
+#define sqlbox_run_query(query, table) \
+if (query != NULL) { \
+    sql = octstr_format(query, table, table, table); \
+    sql_update(pc, sql); \
+    octstr_destroy(sql); \
+}
+
+#undef SQLBOX_TRACE
+
+#endif

--- a/plugins/sqlbox_sql.inc
+++ b/plugins/sqlbox_sql.inc
@@ -1,0 +1,51 @@
+#define sqlbox_sql_c
+#include "sqlbox_sql.h"
+
+struct server_type *sqlbox_init_sql(Cfg *cfg)
+{
+    struct server_type *res = NULL;
+
+#ifdef HAVE_MSSQL
+    res = (struct server_type *)sqlbox_init_mssql(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+#ifdef HAVE_MYSQL
+    res = (struct server_type *)sqlbox_init_mysql(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+#ifdef HAVE_ORACLE
+    res = (struct server_type *)sqlbox_init_oracle(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+#ifdef HAVE_PGSQL
+    res = (struct server_type *)sqlbox_init_pgsql(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+#ifdef HAVE_SDB
+    res = (struct server_type *)sqlbox_init_sdb(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+#ifdef HAVE_SQLITE
+    res = (struct server_type *)sqlbox_init_sqlite(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+#ifdef HAVE_SQLITE3
+    res = (struct server_type *)sqlbox_init_sqlite3(cfg);
+    if (res) {
+        return res;
+    }
+#endif
+    return res;
+}


### PR DESCRIPTION
If you just want logging and no pushing via sqlbox, then this plugin is a nice alternative.

It is based on the sqlbox code. I left the sqlbox naming there, because the files are mainly unaltered. So it's easy to port.
I leave to others to port the other sql backends, like oracle, postgres, etc. That shouldn't be too difficult.
Please don't blame me if it doesn't work ;=).
